### PR TITLE
Fix usage example with topic + correct leaf usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can push the folowing values in json format. When target temperature is chan
 - **`ambient_temperature`** your temperature readings numeric payloads.
 - **`target_temperature`** your thermostat setpoint numeric payloads.
 - **`hvac_state`** string (`off`, `heating`, `cooling`) payload.
-- **`has_leave`** boolean (`true`, `false`) payloads.
+- **`has_leaf`** boolean (`true`, `false`) payloads.
 - **`away`** boolean (`true`, `false`) payloads.
 
 ```
@@ -31,6 +31,8 @@ msg.payload = {
     "hvac_state": "heating",
     "has_leaf": false,
     "away": false
-}
+};
+
+msg.topic = "update";
 
 ```


### PR DESCRIPTION
A fix that in the README.md documentation that otherwise would have saved me a bit of time. I was not aware that I needed to use msg.topic = 'update' to trigger the widget.
